### PR TITLE
🐛 Dynamic import flatfile to prevent reference error

### DIFF
--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,5 +1,4 @@
 import type { NextPage } from "next";
-import { Flatfile } from "@flatfile/sdk";
 
 const employeesEmbedId = "11aa7745-9661-4f7d-a04a-c9b8baa15b94";
 const manifestEmbedId = "5b090352-0167-4a82-bab3-77572deee8de";
@@ -8,6 +7,7 @@ const embedId = manifestEmbedId;
 async function submitData(event: any) {
   event.preventDefault();
   console.log("Importing data...");
+  const { Flatfile } = await import("@flatfile/sdk");
 
   await Flatfile.requestDataFromUser({
     embedId,


### PR DESCRIPTION
Must import Flatfile sdk dynamically in client to prevent this reference error. See https://github.com/vercel/next.js/issues/32014. However, since Flatfile is not a React component, just use regular dynamic import not next/dynamic since it is only for React components

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/10283712/197019459-a4b6c6b3-0ba8-4664-b3b4-5b6476c0a339.png">
